### PR TITLE
Add category/description tag matching and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,24 @@ Configuration keywords
      one of the sources, the item is discarded
    - this works like the logical operator `AND`
 
+ - `descriptionMatch`
+   - a regular expression usable by PCRE (preg_*), ex: `/(foo|bar)/siu`
+   - when at least one `descriptionMatch` matches the description of an item from one of
+     the sources, the item is kept
+   - this works like the logical operator `OR`
+
+ - `descriptionMatchNot`
+   - a regular expression usable by PCRE (preg_*), ex: `/(foo|bar)/siu`
+   - when at least one `descriptionMatchNot` matches the description of an item from one of
+     the sources, the item is discarded
+   - this works like the logical operator `AND NOT`
+
+ - `descriptionMatchMust`
+   - a regular expression usable by PCRE (preg_*), ex: `/(foo|bar)/siu`
+   - when at least one `descriptionMatchMust` doesn't match the description of an item from
+     one of the sources, the item is discarded
+   - this works like the logical operator `AND`
+
  - `categoryMatch`
    - a regular expression usable by PCRE (preg_*), ex: `/(foo|bar)/siu`
    - when at least one `categoryMatch` matches any category of an item from one of

--- a/README.md
+++ b/README.md
@@ -101,10 +101,29 @@ Configuration keywords
    - a regular expression usable by PCRE (preg_*), ex: `/(foo|bar)/siu`
    - when at least one `titleMatchNot` matches the title of an item from one of
      the sources, the item is discarded
+   - this works like the logical operator `AND NOT`
 
  - `titleMatchMust`
    - a regular expression usable by PCRE (preg_*), ex: `/(foo|bar)/siu`
    - when at least one `titleMatchMust` doesn't match the title of an item from
+     one of the sources, the item is discarded
+   - this works like the logical operator `AND`
+
+ - `categoryMatch`
+   - a regular expression usable by PCRE (preg_*), ex: `/(foo|bar)/siu`
+   - when at least one `categoryMatch` matches any category of an item from one of
+     the sources, the item is kept
+   - this works like the logical operator `OR`
+
+ - `categoryMatchNot`
+   - a regular expression usable by PCRE (preg_*), ex: `/(foo|bar)/siu`
+   - when at least one `categoryMatchNot` matches any category of an item from one of
+     the sources, the item is discarded
+   - this works like the logical operator `AND NOT`
+
+ - `categoryMatchMust`
+   - a regular expression usable by PCRE (preg_*), ex: `/(foo|bar)/siu`
+   - when at least one `categoryMatchMust` doesn't match any category of an item from
      one of the sources, the item is discarded
    - this works like the logical operator `AND`
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
 rss-filter
 ==========
 
-
  - http://spenibus.net
  - https://github.com/spenibus/rss-filter-php
  - https://gitlab.com/spenibus/rss-filter-php
  - https://bitbucket.org/spenibus/rss-filter-php
 
-
 This script aggregates and filters rss feeds to output only desired items as a
 single feed.
-
 
 -  Configuration files use the xml extension.
 -  Configuration files must be placed in `./config/`
@@ -22,10 +19,8 @@ single feed.
 -  A configuration file sample is available at `./example.xml`
 -  Configuration keywords are case sensitive, details below.
 
-
 Configuration structure
 -----------------------
-
 
 ````
 <config>
@@ -47,10 +42,8 @@ Configuration structure
 </config>
 ````
 
-
 Configuration keywords
 ----------------------
-
 
  - `config`
    - root element
@@ -157,17 +150,29 @@ Configuration keywords
    - default quantifier is `s` when omitted
    - when an item pubDate is older than the current time minus this duration, the item is discarded
 
-
 Notes
 -----
 
-
  - `rules` blocks only apply to items coming from the `source` elements within the
-same `ruletSet` block
+   same `ruletSet` block
 
  - keywords within a `rules` block only apply to that block, this is important to
-remember when using multiple `rules` block because while one block can exclude
-some items, another block can still include them
+   remember when using multiple `rules` block because while one block can exclude
+   some items, another block can still include them
+
+ - multiple identically named keywords can appear in one `rules` block
+   - multiple `*MatchMust` keywords within one `rules` block are implicitly AND-connected,
+     i.e. **all matches must be true** in order for a feed item to be added to the output 
+   - multiple `*MatchNot` keywords within one `rules` block are implicitly AND-NOT-connected,
+     i.e. **all matches must be false** in order for a feed item to be added to the output
+   - multiple `*Match` keywords within one `rules` block are implicitly OR-connected,
+     i.e. **at least one match must be true** in order for a feed item to be added to the output
+
+ - multiple `ruleSet` elements are implicitly OR-connected,
+   i.e. **at least one `rules` block must be true** in order for a feed item to be added to the output
+
+Examples
+--------
 
 ````
 <rules>
@@ -177,12 +182,10 @@ some items, another block can still include them
     <titleMatchNot>/army/</titleMatchNot>
 </rules>
 ````
-
 
 The example above will return "red army" because the first `rules` block has
 already added the item to the output when the second `rules` block is evaluated.
 
-
 ````
 <rules>
     <titleMatch>/red/</titleMatch>
@@ -190,9 +193,7 @@ already added the item to the output when the second `rules` block is evaluated.
 </rules>
 ````
 
-
 The example above will not return "red army".
-
 
 ````
 <rules>
@@ -204,13 +205,10 @@ The example above will not return "red army".
 </rules>
 ````
 
-
 The example above will also return "red army" because even though the first
 `rules` block has discarded the item, the second one will match it.
 
-
 It is possible to remove unused keywords, as in the example below:
-
 
 ````
 <config>

--- a/class/RssFilter.php
+++ b/class/RssFilter.php
@@ -97,13 +97,16 @@ class RssFilter {
             array('linkDuplicateRemove',  1, true),
             array('rules',                2, false),
             // rules
-            array('titleMatch',     1, false),
-            array('titleMatchNot',  1, false),
-            array('titleMatchMust', 1, false),
-            array('before',         1, true),
-            array('after',          1, true),
-            array('olderThan',      1, true),
-            array('newerThan',      1, true),
+            array('titleMatch',        1, false),
+            array('titleMatchNot',     1, false),
+            array('titleMatchMust',    1, false),
+            array('categoryMatch',     1, false),
+            array('categoryMatchNot',  1, false),
+            array('categoryMatchMust', 1, false),
+            array('before',            1, true),
+            array('after',             1, true),
+            array('olderThan',         1, true),
+            array('newerThan',         1, true),
         );
 
         $this->CFG_KEYWORDS_INDEX = array(
@@ -426,7 +429,7 @@ class RssFilter {
     public function feedsParse() {
 
         // tags to extract
-        $necessary = array('title','link','pubDate');
+        $necessary = array('title','link','pubDate','category');
 
         foreach($this->CFG_CONFIG_DATA['config']['ruleSet'] as $rid=>&$ruleset) {
 
@@ -470,6 +473,7 @@ class RssFilter {
                     $item = array(
                         'raw' => $dom->saveXML($node),
                     );
+                    $categories = array();
 
                     foreach($node->childNodes as $childNode) {
 
@@ -478,9 +482,15 @@ class RssFilter {
 
                         // collect only necessary nodes
                         if(in_array($name, $necessary)) {
-                            $item[$name] = $value;
+                            if($name == 'category') {
+                                $categories[] = $value;
+                            }
+                            else {
+                                $item[$name] = $value;
+                            }
                         }
                     }
+                    $item['category'] = $categories;
 
                     // pubDate timestamp
                     $item['pubDate_timestamp'] = strtotime($item['pubDate']);
@@ -500,6 +510,14 @@ class RssFilter {
 
     /***
     filters items from the sources feeds
+
+    Rules preference:
+      1. Duplicate title/link -> remove
+      2. No rules -> remove
+      3. Any forbidden (MatchNot = AND NOT) title|category match found -> remove
+      4. Any required (MatchMust = AND) title|category match *not* found -> remove
+      5. Any matching (Match = OR) title|category match found -> keep
+      6. Otherwise -> keep
     ***/
     public function itemsFilter() {
 
@@ -559,32 +577,70 @@ class RssFilter {
                     // rule: newerThan
                     || (isset($rules['newerThan']) && $item['pubDate_timestamp'] < $rules['newerThan'])
                 ) {
+                    // Time filter mismatch -> skip ruleset
                     continue;
-                }
-
-                // rule: titleMatchMust
-                if(isset($rules['titleMatchMust']) && is_array($rules['titleMatchMust'])) {
-                    foreach($rules['titleMatchMust'] as $regex) {
-                        if(!preg_match($regex, $item['title'])) {
-
-                            // skip ruleset
-                            continue 2;
-                        }
-                    }
                 }
 
                 // rule: titleMatchNot
                 if(isset($rules['titleMatchNot']) && is_array($rules['titleMatchNot'])) {
                     foreach($rules['titleMatchNot'] as $regex) {
                         if(preg_match($regex, $item['title'])) {
+                            // Forbidden title found -> skip ruleset
+                            continue 2;
+                        }
+                    }
+                }
 
-                            // skip ruleset
+                // rule: categoryMatchNot
+                if(isset($rules['categoryMatchNot']) && is_array($rules['categoryMatchNot'])) {
+                    $matches = false;
+                    foreach($rules['categoryMatchNot'] as $regex) {
+                        if(isset($item['category']) && is_array($item['category'])) {
+                            foreach($item['category'] as $catItem) {
+                                if(preg_match($regex, $catItem)) {
+                                    $matches = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if($matches) {
+                            // Forbidden category found -> skip ruleset
+                            continue 2;
+                        }
+
+                    }
+                }
+
+                // rule: titleMatchMust
+                if(isset($rules['titleMatchMust']) && is_array($rules['titleMatchMust'])) {
+                    foreach($rules['titleMatchMust'] as $regex) {
+                        if(!preg_match($regex, $item['title'])) {
+                            // Required title not found -> skip ruleset
+                            continue 2;
+                        }
+                    }
+                }
+
+                // rule: categoryMatchMust
+                if(isset($rules['categoryMatchMust']) && is_array($rules['categoryMatchMust'])) {
+                    $matches = false;
+                    foreach($rules['categoryMatchMust'] as $regex) {
+                        if(isset($item['category']) && is_array($item['category'])) {
+                            foreach($item['category'] as $catItem) {
+                                if(preg_match($regex, $catItem)) {
+                                    $matches = true;
+                                }
+                            }
+                        }
+                        if(!$matches) {
+                            // Required category not found -> skip ruleset
                             continue 2;
                         }
                     }
                 }
 
                 // rule: titleMatch
+                $titleMatch = true;
                 if(isset($rules['titleMatch']) && is_array($rules['titleMatch'])) {
                     $titleMatch = false;
                     foreach($rules['titleMatch'] as $regex) {
@@ -593,9 +649,30 @@ class RssFilter {
                             break;
                         }
                     }
-                    if(!$titleMatch) {
-                        continue;
+                }
+                if(!$titleMatch) {
+                    // None of the OR-matching titles found -> skip ruleset
+                    continue;
+                }
+
+                // rule: categoryMatch
+                $categoryMatch = true;
+                if(isset($rules['categoryMatch']) && is_array($rules['categoryMatch'])) {
+                    $categoryMatch = false;
+                    foreach($rules['categoryMatch'] as $regex) {
+                        if(isset($item['category']) && is_array($item['category'])) {
+                            foreach($item['category'] as $catItem) {
+                                if(preg_match($regex, $catItem)) {
+                                    $categoryMatch = true;
+                                    break 2;
+                                }
+                            }
+                        }
                     }
+                }
+                if(!$categoryMatch) {
+                    // None of the OR-matching categories found -> skip ruleset
+                    continue;
                 }
 
                 // if we reach this point, the item is a match


### PR DESCRIPTION
Relates to #2.

I did not test this extensively, but to some degree, mostly with my own filters (tell me if you need copies for your own testing) and some local modifications in order to iron out a few glitches. I hope the logic is OK now and does not break your own personal filters.

What is different between categories and titles is that each item has exactly one title, but can have multiple categories, i.e. we need a sub-array and an additional inner loop for each category rule type.