### PR TITLE
Ensure only text content for some nodes

### DIFF
--- a/class/RssFilter.php
+++ b/class/RssFilter.php
@@ -471,34 +471,38 @@ class RssFilter {
                 }
 
                 foreach($nodes as $node) {
-
                     // init
-                    $item = array(
-                        'raw' => $dom->saveXML($node),
-                    );
+                    $item = array();
                     $categories = array();
 
                     foreach($node->childNodes as $childNode) {
-
                         $name  = $childNode->nodeName;
                         $value = $childNode->nodeValue;
+
+                        // ensure only string values for some fields
+                        if($name == 'title' || $name == 'link') {
+                            $childNode->nodeValue = $childNode->textContent;
+                        }
 
                         // collect only necessary nodes
                         if(in_array($name, $necessary)) {
                             if($name == 'category') {
                                 $categories[] = $value;
-                            }
-                            else {
+                            } else {
                                 $item[$name] = $value;
                             }
                         }
                     }
+                    
                     $item['category'] = $categories;
 
                     // pubDate timestamp
                     $item['pubDate_timestamp'] = strtotime($item['pubDate']);
                     $item['ruleset'] = $rid;
                     $item['source']  = $sid;
+
+                    // raw content
+                    $item['raw'] = $dom->saveXML($node);
 
                     // update structure, store items by source
                     $this->CFG_CONFIG_DATA['items'][] = $item;


### PR DESCRIPTION
In a few cases, I've experienced RSS feeds mistakingly including HTML tags in the "title" and "link" fields, making some RSS readers unable to render them. An example is [nltimes](nltimes.nl/rssfeed2). This patch works around that by ensuring that these fields only consist of raw text.